### PR TITLE
add preload option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,10 @@ module.exports.getSTS = function (options) {
     compiled += '; includeSubDomains';
   }
 
+  if (options['preload']) {
+    compiled += '; preload';
+  }
+
   return (req, res, next) => {
     res.setHeader('Strict-Transport-Security', compiled);
     next();

--- a/test/index.js
+++ b/test/index.js
@@ -64,3 +64,28 @@ test('include subdomains', t => {
   t.is(result.name, 'Strict-Transport-Security');
   t.is(result.value, 'max-age=456789; includeSubDomains');
 });
+
+test('preload', t => {
+  const sts = STS.getSTS({
+    'max-age': 456789,
+    'preload': true
+  });
+  const result = {};
+  sts(null, getRes(result), next);
+
+  t.is(result.name, 'Strict-Transport-Security');
+  t.is(result.value, 'max-age=456789; preload');
+});
+
+test('include subdomains and preload', t => {
+  const sts = STS.getSTS({
+    'max-age': 456789,
+    'includeSubDomains': true,
+    'preload': true
+  });
+  const result = {};
+  sts(null, getRes(result), next);
+
+  t.is(result.name, 'Strict-Transport-Security');
+  t.is(result.value, 'max-age=456789; includeSubDomains; preload');
+});


### PR DESCRIPTION
Closes #2.

Add `preload` directive in accordance to `MDN web docs`
- [https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Preloading_Strict_Transport_Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Preloading_Strict_Transport_Security)